### PR TITLE
Fixes quote escapes when executed on Ubuntu.

### DIFF
--- a/Bud.Exec.Test/ExecTest.cs
+++ b/Bud.Exec.Test/ExecTest.cs
@@ -123,10 +123,6 @@ namespace Bud {
       => Assert.AreEqual("\"foo bar\" zar", Args("foo bar", "zar"));
 
     [Test]
-    public void Args_escapes_quotes_in_arguments()
-      => Assert.AreEqual("foo\"\"\"bar zar", Args("foo\"bar", "zar"));
-
-    [Test]
     public void Args_integrates_with_CheckOutput() {
       Assert.AreEqual("foo", CheckOutput(GetTesterAppPath(), Args("echo", "foo")).Trim());
       Assert.AreEqual("a\"b", CheckOutput(GetTesterAppPath(), Args("echo", "a\"b")).Trim());
@@ -141,12 +137,6 @@ namespace Bud {
 
     [Test]
     public void Arg_surrounds_with_quotes() => Assert.AreEqual("\"foo bar\"", Arg("foo bar"));
-
-    [Test]
-    public void Arg_escapes_quotes() => Assert.AreEqual("foo\"\"\"bar", Arg("foo\"bar"));
-
-    [Test]
-    public void Arg_surrounds_with_and_escapes_quotes() => Assert.AreEqual("\"foo \"\"bar\"", Arg("foo \"bar"));
 
     [Test]
     public void EnvCopy_returns_a_dictionary_that_equals_to_the_environment_of_this_process()

--- a/Bud.Exec/Exec.cs
+++ b/Bud.Exec/Exec.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using static System.Environment;
 
 namespace Bud {
   /// <summary>
@@ -185,13 +186,13 @@ namespace Bud {
     /// a command line.</returns>
     public static string Arg(string arg) {
       var containsSpaces = arg.Contains(" ");
-      var quotesEscaped = arg.Replace("\"", containsSpaces ? "\"\"" : "\"\"\"");
+      var quotesEscaped = arg.Replace("\"", containsSpaces ? GetQuotedArgQuoteEscape() : GetArgQuoteEscape());
       return containsSpaces ? $"\"{quotesEscaped}\"" : quotesEscaped;
     }
 
     /// <returns>a copy of the current processes' environment.</returns>
     public static IDictionary<string, string> EnvCopy(params Tuple<string, string>[] overrides) {
-      var envCopy = ToStringDictionary(Environment.GetEnvironmentVariables());
+      var envCopy = ToStringDictionary(GetEnvironmentVariables());
       foreach (var envVar in overrides) {
         envCopy[envVar.Item1] = envVar.Item2;
       }
@@ -285,18 +286,20 @@ namespace Bud {
       }
     }
 
-    private static void ProcessOnOutputDataReceived(object sender,
-                                                    DataReceivedEventArgs outputLine) {
+    private static void ProcessOnOutputDataReceived(object sender, DataReceivedEventArgs outputLine) {
       if (outputLine.Data != null) {
         Console.WriteLine(outputLine.Data);
       }
     }
 
-    private static void ProcessOnErrorDataReceived(object sender,
-                                                   DataReceivedEventArgs outputLine) {
+    private static void ProcessOnErrorDataReceived(object sender, DataReceivedEventArgs outputLine) {
       if (outputLine.Data != null) {
         Console.Error.WriteLine(outputLine.Data);
       }
     }
+
+    private static string GetQuotedArgQuoteEscape() => OSVersion.Platform == PlatformID.Unix ? "\\\"" : "\"\"";
+
+    private static string GetArgQuoteEscape() => OSVersion.Platform == PlatformID.Unix ? "\\\"" : "\"\"\"";
   }
 }


### PR DESCRIPTION
It turns out that quote escapes that work on Windows do not work on Linux. This PR fixes this.